### PR TITLE
Fix issue when collector is deleted manually

### DIFF
--- a/go-sumologic/sumologic_client.go
+++ b/go-sumologic/sumologic_client.go
@@ -99,6 +99,10 @@ func (s *SumologicClient) Get(urlPath string) ([]byte, string, error) {
 
 	d, _ := ioutil.ReadAll(resp.Body)
 
+	if resp.StatusCode == 404 {
+		return nil, "", nil
+	}
+
 	if resp.StatusCode >= 400 {
 		var errorResponse ErrorResponse
 		_ = json.Unmarshal(d, &errorResponse)

--- a/provider/resource_sumologic_collector.go
+++ b/provider/resource_sumologic_collector.go
@@ -58,6 +58,11 @@ func resourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	if collector == nil {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("name", collector.Name)
 	d.Set("description", collector.Description)
 	d.Set("category", collector.Category)


### PR DESCRIPTION
When a collector no longer exists in SumoLogic, the API will return a 404. This is interpreted as an error by the provider, which in turn breaks the template.

This commit should fix that (no tests)